### PR TITLE
Contribution Guidelines draft

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contribution Guidelines for LBSR Training Repository
+
+## Getting Involved
+
+-TBD
+
+## Label Usage in Issues and Pull Requests
+
+- TBD


### PR DESCRIPTION
Just a first draft of the contribution guidelines using the standard CONTRIBUTING.md document naming expected by GitHub.
